### PR TITLE
Bug fixes and general improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # make-unix-timestamp-c
 ## Purpose
-Provides a simple C function that takes datetime elements (e.g. `seconds`, `minutes`, `hours`, `date`, `month` and `year`) and returns a single integer representing the number of seconds elapsed since the UNIX epoch (1/1/1970).
+Provides a simple C function that takes datetime elements (e.g. `hours`, `minutes`, `seconds`, `date`, `month` and `year`) and returns a single integer representing the number of seconds elapsed since the UNIX epoch (1/1/1970).
 
 ```c
 uint32_t
-unix_time_in_seconds( uint8_t sec, uint8_t min, uint8_t hrs, uint8_t day, uint8_t mon, uint16_t year );
+unix_time_in_seconds( uint8_t hrs, uint8_t min, uint8_t sec, uint8_t day, uint8_t mon, uint16_t year );
 ```
 
 This is a fairly common problem I've encountered, as many off-the-shelf RTC integrated circuits seem to only provide datetime output as the individual datetime elements, each accessed by a separate register.  However, it is easier to do most datetime/timer/looper logic operations using a well ordered set such as the integers, for which purpose a UNIX timestamp is ideal.
@@ -19,7 +19,7 @@ make && ./example
 The example app simply takes the datetime 6:53:16Z Nov 22th, 2015 and prints out the UNIX timestamp in seconds (should be `1448175196`).
 
 ```c
-  uint32_t ts = unix_time_in_seconds( 16, 53, 06, 22, 11, 2015 );
+  uint32_t ts = unix_time_in_seconds( 6, 53, 16, 22, 11, 2015 );
   printf( "%d\n", ts );
 ```
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+![Status](https://img.shields.io/badge/Status-Finished-green.svg)
+
 # make-unix-timestamp-c
 ## Purpose
 Provides a simple C function that takes datetime elements (e.g. `hours`, `minutes`, `seconds`, `date`, `month` and `year`) and returns a single integer representing the number of seconds elapsed since the UNIX epoch (1/1/1970).

--- a/example.c
+++ b/example.c
@@ -3,6 +3,6 @@
 
 int main()
 {
-  uint32_t ts = unix_time_in_seconds( 16, 53, 06, 22, 11, 2015 );
+  uint32_t ts = unix_time_in_seconds( 6, 53, 16, 22, 11, 2015 );
   printf( "%d\n", ts );
 }

--- a/mktime.c
+++ b/mktime.c
@@ -1,7 +1,7 @@
 #include "mktime.h"
 
 uint32_t
-unix_time_in_seconds( uint8_t sec, uint8_t min, uint8_t hrs, uint8_t day, uint8_t mon, uint16_t year )
+unix_time_in_seconds( uint8_t hrs, uint8_t min, uint8_t sec, uint8_t day, uint8_t mon, uint16_t year )
 {
   uint32_t ts = 0;
 
@@ -28,9 +28,9 @@ unix_time_in_seconds( uint8_t sec, uint8_t min, uint8_t hrs, uint8_t day, uint8_
   ts += (day-1) * SEC_PER_DAY; // days from this month
 
   //  Calculate seconds elapsed just today.
-  ts += hrs * SEC_PER_HOUR;
-  ts += min * SEC_PER_MIN;
-  ts += sec;
+  ts += (uint32_t)hrs * SEC_PER_HOUR;
+  ts += (uint32_t)min * SEC_PER_MIN;
+  ts += (uint32_t)sec;
 
   return ts;
 }

--- a/mktime.h
+++ b/mktime.h
@@ -17,4 +17,4 @@ static int days_per_year[2] = {
 };
 
 uint32_t
-unix_time_in_seconds( uint8_t sec, uint8_t min, uint8_t hrs, uint8_t day, uint8_t mon, uint16_t year );
+unix_time_in_seconds( uint8_t hrs, uint8_t min, uint8_t sec, uint8_t day, uint8_t mon, uint16_t year );


### PR DESCRIPTION
- In the mktime.c file, performing calculations using variables of different types (uint32_t and uint8_t) was generating erroneous timestamp values whenever the time parameter was greater than 9 (two digits). The correction was performed through the casting technique of the variables of different types. The problem appeared while compiling the code for an MSP430 microcontroller using the Code Composer Studio IDE (CCS).

- As a general improvement, the order of the 'sec' parameters with the 'hrs' was inverted. In this way, these parameters will be passed to the function in the same way as the time representation that is in the example provided.